### PR TITLE
FB-2585 Align initial project api with endpoints provided from backend

### DIFF
--- a/src/api/projects/projectsApi.ts
+++ b/src/api/projects/projectsApi.ts
@@ -3,77 +3,136 @@ import type { SavedDocumentResponse } from "@/types/types";
 
 import { api } from "../api";
 
-// QUERIES
-// /api/v1/projects/{id}/pages    ### Single Project By Id / Pages
-// /api/v1/projects/{id}/saved-sources    ### Single Project By Id / saved-sources (ex: inbox/documents?)
-// /api/v1/projects/{id}/overview ### Single Project By Id / overview
-// /api/v1/projects/{id}/structure ### Single Project By Id / structure (needs to render one level higher than the page/subs)
-// /api/v1/projects/{id}/tabs/{id}  ### Single Project By Id / Tabs / TabID - list the tabs
-// /api/v1/projects/{id}/statistics ### Single Project By Id / Stats
-// /api/v1/projects/{id}/notifications  ### Single Project By Id / notifications
-
-// MUTATIONS
-// PUT /api/projects/{projectId}/tabs/order  ## Assign Tab Order
-
-// MatRad:
-// /api/v1/projects               ### All
-// /api/v1/projects/{id}          ### Single Project By Id
-// /api/v1/projects/{id}/tabs     ### Single Project By Id -> Tabs
-// /api/v1/results-overview-tables/{id}
-// /api/v1/maturity-radar/{id}/api/v1/projects/{id}/pages -> add to pages
-// /api/v1/projects/{projectId}/pages/{pageId} -> http delete, remove page
-
-export const projectApi = api.injectEndpoints({
+export const projectsApi = api.injectEndpoints({
   endpoints: (builder) => ({
+    // Fetch all projects
     getProjects: builder.query<SavedDocumentResponse, { page: number; limit: number }>({
       query: ({ page, limit }) => ({
         url: "/v1/projects",
-        params: {
-          page,
-          limit,
-        },
+        params: { page, limit },
       }),
-      // providesTags: ["Project"],
+      providesTags: ["Project"],
     }),
 
-    getSavedMaturityRadars: builder.query<SavedDocumentResponse, { page: number; limit: number }>({
-      query: ({ page, limit }) => ({
-        url: "/maturity-radar/4/08dd1e7c-8f94-478d-89ea-7d6cfae32a8e",
-        params: {
-          orderBy: 2,
-          doIncludePatents: true,
-          doIncludeScienceArticles: true,
-          doIncludeWeblinks: true,
-          createdByMe: true,
-          page,
-          limit,
-        },
+    // Single project's pages
+    getProjectPages: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/projects/${id}/pages`,
+      providesTags: (result, error, id) => [{ type: "ProjectPages", id }],
+    }),
+
+    // Single project's saved sources
+    getProjectSavedSources: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/projects/${id}/saved-sources`,
+      providesTags: (result, error, id) => [{ type: "ProjectSavedSources", id }],
+    }),
+
+    // Single project's overview
+    getProjectOverview: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/projects/${id}/overview`,
+      providesTags: (result, error, id) => [{ type: "ProjectOverview", id }],
+    }),
+
+    // Single project's structure
+    getProjectStructure: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/projects/${id}/structure`,
+      providesTags: (result, error, id) => [{ type: "ProjectStructure", id }],
+    }),
+
+    // Single project's tabs
+    getProjectTabs: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/projects/${id}/tabs`,
+      providesTags: (result, error, id) => [{ type: "ProjectTabs", id }],
+    }),
+
+    // Get specific tab inside a project
+    getProjectTabById: builder.query<SavedDocumentResponse, { projectId: string; tabId: string }>({
+      query: ({ projectId, tabId }) => `/v1/projects/${projectId}/tabs/${tabId}`,
+      providesTags: (result, error, { tabId }) => [{ type: "ProjectTab", id: tabId }],
+    }),
+
+    // Single project's statistics
+    getProjectStatistics: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/projects/${id}/statistics`,
+      providesTags: (result, error, id) => [{ type: "ProjectStatistics", id }],
+    }),
+
+    // Ssingle project's notifications
+    getProjectNotifications: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/projects/${id}/notifications`,
+      providesTags: (result, error, id) => [{ type: "ProjectNotifications", id }],
+    }),
+
+    // Update tab order in a project
+    updateProjectTabOrder: builder.mutation<void, { projectId: string; newOrder: number[] }>({
+      query: ({ projectId, newOrder }) => ({
+        url: `/projects/${projectId}/tabs/order`,
+        method: "PUT",
+        body: { newOrder },
       }),
-      providesTags: ["SavedDocument"],
+      invalidatesTags: [{ type: "ProjectTabs" }],
     }),
 
-    getMaturityRadar: builder.query<SavedDocumentResponse, string>({
-      query: (id) => `/maturity-radar/4/${id}`,
-      providesTags: (result, error, id) => [{ type: "SavedDocument", id }],
-      overrideExisting: true,
+    // Fetch all projects (Maturity Radar related)
+    getAllProjects: builder.query<SavedDocumentResponse, void>({
+      query: () => "/v1/projects",
+      providesTags: ["Project"],
     }),
 
-    createMaturityRadar: builder.mutation({
-      queryFn: (id) => {
-        return {
-          data: {
-            id,
-            status: "success",
-            message: "Dummy response for createMaturityRadar",
-            createdAt: new Date().toISOString(),
-          },
-        };
-      },
-      providesTags: (result, error, id) => [{ type: "SavedDocument", id }],
-      overrideExisting: true,
+    // 📌 Fetch a single project by ID
+    getProjectById: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/projects/${id}`,
+      providesTags: (result, error, id) => [{ type: "Project", id }],
+    }),
+
+    // Project's maturity radar data
+    getProjectMaturityRadar: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/projects/${id}/maturity-radar`,
+      providesTags: (result, error, id) => [{ type: "MaturityRadar", id }],
+    }),
+
+    // Results overview table
+    getResultsOverviewTable: builder.query<SavedDocumentResponse, string>({
+      query: (id) => `/v1/results-overview-tables/${id}`,
+      providesTags: (result, error, id) => [{ type: "ResultsOverviewTable", id }],
+    }),
+
+    // Add Maturity Radar data to pages
+    addMaturityRadarToPages: builder.mutation<void, { projectId: string; pageId: string }>({
+      query: ({ projectId, pageId }) => ({
+        url: `/v1/maturity-radar/${projectId}/pages/${pageId}`,
+        method: "POST",
+      }),
+      invalidatesTags: [{ type: "MaturityRadar" }],
+    }),
+
+    // Remove page from a project
+    deleteProjectPage: builder.mutation<void, { projectId: string; pageId: string }>({
+      query: ({ projectId, pageId }) => ({
+        url: `/v1/projects/${projectId}/pages/${pageId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: [{ type: "ProjectPages" }],
     }),
   }),
 });
 
-export const { useGetProjectsQuery, useGetMaturityRadarQuery, useCreateMaturityRadarMutation } =
-  projectApi;
+// Hooks for Queries and Mutations
+
+export const {
+  useGetProjectsQuery,
+  useGetProjectPagesQuery,
+  useGetProjectSavedSourcesQuery,
+  useGetProjectOverviewQuery,
+  useGetProjectStructureQuery,
+  useGetProjectTabsQuery,
+  useGetProjectTabByIdQuery,
+  useGetProjectStatisticsQuery,
+  useGetProjectNotificationsQuery,
+  useUpdateProjectTabOrderMutation,
+  useGetAllProjectsQuery,
+  useGetProjectByIdQuery,
+  useGetProjectMaturityRadarQuery,
+  useGetResultsOverviewTableQuery,
+  useAddMaturityRadarToPagesMutation,
+  useDeleteProjectPageMutation,
+} = projectsApi;

--- a/src/api/projects/projectsApi.ts
+++ b/src/api/projects/projectsApi.ts
@@ -3,10 +3,39 @@ import type { SavedDocumentResponse } from "@/types/types";
 
 import { api } from "../api";
 
-// Maturity Radar, Requirements Table
+// QUERIES
+// /api/v1/projects/{id}/pages    ### Single Project By Id / Pages
+// /api/v1/projects/{id}/saved-sources    ### Single Project By Id / saved-sources (ex: inbox/documents?)
+// /api/v1/projects/{id}/overview ### Single Project By Id / overview
+// /api/v1/projects/{id}/structure ### Single Project By Id / structure (needs to render one level higher than the page/subs)
+// /api/v1/projects/{id}/tabs/{id}  ### Single Project By Id / Tabs / TabID - list the tabs
+// /api/v1/projects/{id}/statistics ### Single Project By Id / Stats
+// /api/v1/projects/{id}/notifications  ### Single Project By Id / notifications
+
+// MUTATIONS
+// PUT /api/projects/{projectId}/tabs/order  ## Assign Tab Order
+
+// MatRad:
+// /api/v1/projects               ### All
+// /api/v1/projects/{id}          ### Single Project By Id
+// /api/v1/projects/{id}/tabs     ### Single Project By Id -> Tabs
+// /api/v1/results-overview-tables/{id}
+// /api/v1/maturity-radar/{id}/api/v1/projects/{id}/pages -> add to pages
+// /api/v1/projects/{projectId}/pages/{pageId} -> http delete, remove page
 
 export const projectApi = api.injectEndpoints({
   endpoints: (builder) => ({
+    getProjects: builder.query<SavedDocumentResponse, { page: number; limit: number }>({
+      query: ({ page, limit }) => ({
+        url: "/v1/projects",
+        params: {
+          page,
+          limit,
+        },
+      }),
+      // providesTags: ["Project"],
+    }),
+
     getSavedMaturityRadars: builder.query<SavedDocumentResponse, { page: number; limit: number }>({
       query: ({ page, limit }) => ({
         url: "/maturity-radar/4/08dd1e7c-8f94-478d-89ea-7d6cfae32a8e",
@@ -46,4 +75,5 @@ export const projectApi = api.injectEndpoints({
   }),
 });
 
-export const { useGetMaturityRadarQuery, useCreateMaturityRadarMutation } = projectApi;
+export const { useGetProjectsQuery, useGetMaturityRadarQuery, useCreateMaturityRadarMutation } =
+  projectApi;


### PR DESCRIPTION
As relates to ProjectsAPI will merge to main.
Creates projectsApi Redux slice (RTKQuery), to establish basic structure/queries/mutations, corresponding to the schema created by @obegendi 

Fetch all projects | GET | /api/v1/projects
Fetch single project | GET | /api/v1/projects/{id}
Fetch project pages | GET | /api/v1/projects/{id}/pages
Fetch saved sources | GET | /api/v1/projects/{id}/saved-sources
Fetch overview | GET | /api/v1/projects/{id}/overview
Fetch structure | GET | /api/v1/projects/{id}/structure
Fetch tabs | GET | /api/v1/projects/{id}/tabs
Fetch a tab by ID | GET | /api/v1/projects/{id}/tabs/{id}
Fetch statistics | GET | /api/v1/projects/{id}/statistics
Fetch notifications | GET | /api/v1/projects/{id}/notifications
Update tab order | PUT | /api/projects/{projectId}/tabs/order
Fetch maturity radar | GET | /api/v1/projects/{id}/maturity-radar
Fetch results overview table | GET | /api/v1/results-overview-tables/{id}
Add maturity radar to pages | POST | /api/v1/maturity-radar/{id}/api/v1/projects/{id}/pages
Delete a project page | DELETE | /api/v1/projects/{projectId}/pages/{pageId}